### PR TITLE
Remove hyperopt_reference

### DIFF
--- a/user_data/strategies/berlinguyinca/ASDTSRockwellTrading.py
+++ b/user_data/strategies/berlinguyinca/ASDTSRockwellTrading.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/AverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/AverageStrategy.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/BinHV27.py
+++ b/user_data/strategies/berlinguyinca/BinHV27.py
@@ -1,6 +1,5 @@
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -8,7 +7,6 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/BinHV45.py
+++ b/user_data/strategies/berlinguyinca/BinHV45.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 import numpy as np

--- a/user_data/strategies/berlinguyinca/CCIStrategy.py
+++ b/user_data/strategies/berlinguyinca/CCIStrategy.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, Series, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/ClucMay72018.py
+++ b/user_data/strategies/berlinguyinca/ClucMay72018.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -9,7 +8,6 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/EMASkipPump.py
+++ b/user_data/strategies/berlinguyinca/EMASkipPump.py
@@ -1,6 +1,5 @@
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/Low_BB.py
+++ b/user_data/strategies/berlinguyinca/Low_BB.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -9,7 +8,6 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/MACDStrategy.py
+++ b/user_data/strategies/berlinguyinca/MACDStrategy.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/Quickie.py
+++ b/user_data/strategies/berlinguyinca/Quickie.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, merge, DatetimeIndex
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/ReinforcedQuickie.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedQuickie.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -9,7 +8,6 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
@@ -1,14 +1,12 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/Scalp.py
+++ b/user_data/strategies/berlinguyinca/Scalp.py
@@ -1,15 +1,13 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
-from functools import reduce
+from functools import rweduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------
 import talib.abstract as ta

--- a/user_data/strategies/berlinguyinca/Simple.py
+++ b/user_data/strategies/berlinguyinca/Simple.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/SmoothOperator.py
+++ b/user_data/strategies/berlinguyinca/SmoothOperator.py
@@ -1,7 +1,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/berlinguyinca/SmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/SmoothScalp.py
@@ -1,14 +1,12 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------

--- a/user_data/strategies/strategy001.py
+++ b/user_data/strategies/strategy001.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -20,7 +19,7 @@ class strategy001(IStrategy):
     author@: Gerald Lonlas
     github@: https://github.com/freqtrade/freqtrade-strategies
 
-    How to use it? 
+    How to use it?
     > python3 ./freqtrade/main.py -s Strategy001
     """
 

--- a/user_data/strategies/strategy002.py
+++ b/user_data/strategies/strategy002.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -17,7 +16,7 @@ class strategy002(IStrategy):
     author@: Gerald Lonlas
     github@: https://github.com/freqtrade/freqtrade-strategies
 
-    How to use it? 
+    How to use it?
     > python3 ./freqtrade/main.py -s Strategy002
     """
 

--- a/user_data/strategies/strategy003.py
+++ b/user_data/strategies/strategy003.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -17,7 +16,7 @@ class strategy003(IStrategy):
     author@: Gerald Lonlas
     github@: https://github.com/freqtrade/freqtrade-strategies
 
-    How to use it? 
+    How to use it?
     > python3 ./freqtrade/main.py -s Strategy003
     """
 

--- a/user_data/strategies/strategy004.py
+++ b/user_data/strategies/strategy004.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------
@@ -16,7 +15,7 @@ class strategy004(IStrategy):
     author@: Gerald Lonlas
     github@: https://github.com/freqtrade/freqtrade-strategies
 
-    How to use it? 
+    How to use it?
     > python3 ./freqtrade/main.py -s Strategy004
     """
 

--- a/user_data/strategies/strategy005.py
+++ b/user_data/strategies/strategy005.py
@@ -2,7 +2,6 @@
 # --- Do not remove these libs ---
 from freqtrade.strategy.interface import IStrategy
 from typing import Dict, List
-from hyperopt import hp
 from functools import reduce
 from pandas import DataFrame
 # --------------------------------


### PR DESCRIPTION
## Summary
Remove references to hyperopt, since it's not in the bot's requirements file anymore (since [#930](https://github.com/freqtrade/freqtrade/pull/930) ) it will create problems for new installations.
