### PR TITLE
Add informpairs

### DIFF
--- a/user_data/strategies/InformativeSample.py
+++ b/user_data/strategies/InformativeSample.py
@@ -89,7 +89,7 @@ class InformativeSample(IStrategy):
         dataframe['ema50'] = ta.EMA(dataframe, timeperiod=50)
         dataframe['ema100'] = ta.EMA(dataframe, timeperiod=100)
         if self.dp:
-            if self.dp.runmode == 'live':
+            if self.dp.runmode in('live', 'dry_run'):
                 # Compare stake-currency with USDT - using the defined ticker-interval
                 if (f"{self.stake_currency}/USDT", self.ticker_interval) in self.dp.available_pairs:
                     data = self.dp.ohlcv(pair='ETH/BTC',

--- a/user_data/strategies/Strategy001.py
+++ b/user_data/strategies/Strategy001.py
@@ -63,6 +63,19 @@ class Strategy001(IStrategy):
         'stoploss_on_exchange': False
     }
 
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/user_data/strategies/Strategy002.py
+++ b/user_data/strategies/Strategy002.py
@@ -60,6 +60,19 @@ class Strategy002(IStrategy):
         'stoploss_on_exchange': False
     }
 
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/user_data/strategies/Strategy003.py
+++ b/user_data/strategies/Strategy003.py
@@ -60,6 +60,19 @@ class Strategy003(IStrategy):
         'stoploss_on_exchange': False
     }
 
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame

--- a/user_data/strategies/Strategy004.py
+++ b/user_data/strategies/Strategy004.py
@@ -58,6 +58,19 @@ class Strategy004(IStrategy):
         'stoploss': 'market',
         'stoploss_on_exchange': False
     }
+    
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """

--- a/user_data/strategies/Strategy005.py
+++ b/user_data/strategies/Strategy005.py
@@ -62,6 +62,19 @@ class Strategy005(IStrategy):
         'stoploss_on_exchange': False
     }
 
+    def informative_pairs(self):
+        """
+        Define additional, informative pair/interval combinations to be cached from the exchange.
+        These pair/interval combinations are non-tradeable, unless they are part
+        of the whitelist as well.
+        For more information, please consult the documentation
+        :return: List of tuples in the format (pair, interval)
+            Sample: return [("ETH/USDT", "5m"),
+                            ("BTC/USDT", "15m"),
+                            ]
+        """
+        return []
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Adds several different TA indicators to the given DataFrame


### PR DESCRIPTION
## Summary
Add sample strategy implementing informative pairs.

The strategy itself is just for demonstration purposes - the "regular" buy/sell signals are too basic for good performance.

https://github.com/freqtrade/freqtrade/issues/1669
