### PR TITLE
fix populate_sell_trend()

### DIFF
--- a/user_data/strategies/berlinguyinca/ADXMomentum.py
+++ b/user_data/strategies/berlinguyinca/ADXMomentum.py
@@ -61,5 +61,5 @@ class ADXMomentun(IStrategy):
                     (dataframe['plus_di'] > dataframe['minus_di'])
 
             ),
-            'sell'] = 0
+            'sell'] = 1
         return dataframe


### PR DESCRIPTION
populate_sell_trend() did not set 'sell' to 1, fixed. 

As far as I understand, the trades closed only on achieving min_roi or on stoploss.

Maybe the hyperoptimization for min_roi for this strategy should be made again since its value currently defined in the strategy may now be non-optimal.

Results of backtesting in README.md should be reviewed and changed if needed.

P.S. If this change is correct, there are 7 more appearances of same bug in this directory, just grepped for it.
