### PR TITLE
MACDStrategy_crossed

### DIFF
--- a/user_data/strategies/berlinguyinca/MACDStrategy.py
+++ b/user_data/strategies/berlinguyinca/MACDStrategy.py
@@ -7,7 +7,6 @@ from pandas import DataFrame
 # --------------------------------
 
 import talib.abstract as ta
-import freqtrade.vendor.qtpylib.indicators as qtpylib
 
 
 class MACDStrategy(IStrategy):
@@ -22,7 +21,7 @@ class MACDStrategy(IStrategy):
             and CCI < -50
 
         downtrend definition:
-            MACD below 0 line and below MACD signal
+            MACD below MACD signal
             and CCI > 100
 
     """
@@ -77,7 +76,8 @@ class MACDStrategy(IStrategy):
         dataframe.loc[
             (
                 (dataframe['macd'] < dataframe['macdsignal']) &
-                (dataframe['cci'] >= 100)
+                (dataframe['cci'] >= 100.0)
             ),
             'sell'] = 1
+
         return dataframe

--- a/user_data/strategies/berlinguyinca/MACDStrategy_crossed.py
+++ b/user_data/strategies/berlinguyinca/MACDStrategy_crossed.py
@@ -1,0 +1,77 @@
+
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from typing import Dict, List
+from functools import reduce
+from pandas import DataFrame
+# --------------------------------
+
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+
+
+class MACDStrategy_crossed(IStrategy):
+    """
+        buy:
+            MACD crosses MACD signal above
+            and CCI < -50
+        sell:
+            MACD crosses MACD signal below
+            and CCI > 100
+    """
+
+    # Minimal ROI designed for the strategy.
+    # This attribute will be overridden if the config file contains "minimal_roi"
+    minimal_roi = {
+        "60":  0.01,
+        "30":  0.03,
+        "20":  0.04,
+        "0":  0.05
+    }
+
+    # Optimal stoploss designed for the strategy
+    # This attribute will be overridden if the config file contains "stoploss"
+    stoploss = -0.3
+
+    # Optimal ticker interval for the strategy
+    ticker_interval = '5m'
+
+    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+
+        macd = ta.MACD(dataframe)
+        dataframe['macd'] = macd['macd']
+        dataframe['macdsignal'] = macd['macdsignal']
+        dataframe['macdhist'] = macd['macdhist']
+        dataframe['cci'] = ta.CCI(dataframe)
+
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+        """
+        Based on TA indicators, populates the buy signal for the given dataframe
+        :param dataframe: DataFrame
+        :return: DataFrame with buy column
+        """
+        dataframe.loc[
+            (
+                qtpylib.crossed_above(dataframe['macd'], dataframe['macdsignal']) &
+                (dataframe['cci'] <= -50.0)
+            ),
+            'buy'] = 1
+
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+        """
+        Based on TA indicators, populates the sell signal for the given dataframe
+        :param dataframe: DataFrame
+        :return: DataFrame with buy column
+        """
+        dataframe.loc[
+            (
+                qtpylib.crossed_below(dataframe['macd'], dataframe['macdsignal']) &
+                (dataframe['cci'] >= 100.0)
+            ),
+            'sell'] = 1
+
+        return dataframe


### PR DESCRIPTION
I'm not sure if it's proper place for yet another strategy since these are the strategies by @berlinguyinca as the name of the catalog says, hope it fits...

This is a strategy complement to MACDStrategy: it uses crossed_above() and crossed_below() instead of comparison of macd with macdsignal.

I found it would be interesting and probably useful to have such a couple of complement strategies here 1) for testing purposes, 2) to have an ability to compare the behaviour of these 2 similar signals at different markets and market conditions.

Minor cosmetics to original MACDStrategy included.
