### PR TITLE
hyperopt for MACDStrategy

### DIFF
--- a/user_data/hyperopts/MACDStrategy_hyperopt.py
+++ b/user_data/hyperopts/MACDStrategy_hyperopt.py
@@ -3,12 +3,11 @@
 import talib.abstract as ta
 from pandas import DataFrame
 from typing import Dict, Any, Callable, List
-from functools import reduce
 
-import numpy
+# import numpy as np
 from skopt.space import Categorical, Dimension, Integer, Real
 
-import freqtrade.vendor.qtpylib.indicators as qtpylib
+# import freqtrade.vendor.qtpylib.indicators as qtpylib
 from freqtrade.optimize.hyperopt_interface import IHyperOpt
 
 class_name = 'MACDStrategy_hyperopt'
@@ -17,20 +16,22 @@ class_name = 'MACDStrategy_hyperopt'
 # This class is a sample. Feel free to customize it.
 class MACDStrategy_hyperopt(IHyperOpt):
     """
-    This is a test hyperopt to inspire you.
+    This is an Example hyperopt to inspire you. - corresponding to MACDStrategy in this repository.
+
+    To run this, best use the following command (adjust to your environment
+    ```
+    freqtrade hyperopt --strategy MACDStrategy --hyperopts MACDStrategy_hyperopt --spaces buy sell
+    ```
+    The idea is to optimize only the CCI value.
+    - Buy side: CCI between -700 and 0
+    - Sell side: CCI between 0 and 700
+
     More information in https://github.com/freqtrade/freqtrade/blob/develop/docs/hyperopt.md
-     You can:
-    - Rename the class name (Do not forget to update class_name)
-    - Add any methods you want to build your hyperopt
-    - Add any lib you need to build your hyperopt
-     You must keep:
-    - the prototype for the methods: populate_indicators, indicator_space, buy_strategy_generator,
-    roi_space, generate_roi_table, stoploss_space
-    """
+     """
 
     @staticmethod
     def populate_indicators(dataframe: DataFrame, metadata: dict) -> DataFrame:
-       
+
         macd = ta.MACD(dataframe)
         dataframe['macd'] = macd['macd']
         dataframe['macdsignal'] = macd['macdsignal']
@@ -95,42 +96,6 @@ class MACDStrategy_hyperopt(IHyperOpt):
         """
         return [
             Integer(0, 700, name='sell-cci-value'),
-        ]
-
-    @staticmethod
-    def generate_roi_table(params: Dict) -> Dict[int, float]:
-        """
-        Generate the ROI table that will be used by Hyperopt
-        """
-        roi_table = {}
-        roi_table[0] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']
-        roi_table[params['roi_t3']] = params['roi_p1'] + params['roi_p2']
-        roi_table[params['roi_t3'] + params['roi_t2']] = params['roi_p1']
-        roi_table[params['roi_t3'] + params['roi_t2'] + params['roi_t1']] = 0
-
-        return roi_table
-
-    @staticmethod
-    def stoploss_space() -> List[Dimension]:
-        """
-        Stoploss Value to search
-        """
-        return [
-            Real(-0.5, -0.02, name='stoploss'),
-        ]
-
-    @staticmethod
-    def roi_space() -> List[Dimension]:
-        """
-        Values to search for each ROI steps
-        """
-        return [
-            Integer(10, 120, name='roi_t1'),
-            Integer(10, 60, name='roi_t2'),
-            Integer(10, 40, name='roi_t3'),
-            Real(0.01, 0.04, name='roi_p1'),
-            Real(0.01, 0.07, name='roi_p2'),
-            Real(0.01, 0.20, name='roi_p3'),
         ]
 
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:

--- a/user_data/hyperopts/MACDStrategy_hyperopt.py
+++ b/user_data/hyperopts/MACDStrategy_hyperopt.py
@@ -1,0 +1,164 @@
+# pragma pylint: disable=missing-docstring, invalid-name, pointless-string-statement
+
+import talib.abstract as ta
+from pandas import DataFrame
+from typing import Dict, Any, Callable, List
+from functools import reduce
+
+import numpy
+from skopt.space import Categorical, Dimension, Integer, Real
+
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+from freqtrade.optimize.hyperopt_interface import IHyperOpt
+
+class_name = 'MACDStrategy_hyperopt'
+
+
+# This class is a sample. Feel free to customize it.
+class MACDStrategy_hyperopt(IHyperOpt):
+    """
+    This is a test hyperopt to inspire you.
+    More information in https://github.com/freqtrade/freqtrade/blob/develop/docs/hyperopt.md
+     You can:
+    - Rename the class name (Do not forget to update class_name)
+    - Add any methods you want to build your hyperopt
+    - Add any lib you need to build your hyperopt
+     You must keep:
+    - the prototype for the methods: populate_indicators, indicator_space, buy_strategy_generator,
+    roi_space, generate_roi_table, stoploss_space
+    """
+
+    @staticmethod
+    def populate_indicators(dataframe: DataFrame, metadata: dict) -> DataFrame:
+       
+        macd = ta.MACD(dataframe)
+        dataframe['macd'] = macd['macd']
+        dataframe['macdsignal'] = macd['macdsignal']
+        dataframe['macdhist'] = macd['macdhist']
+        dataframe['cci'] = ta.CCI(dataframe)
+
+        return dataframe
+
+    @staticmethod
+    def buy_strategy_generator(params: Dict[str, Any]) -> Callable:
+        """
+        Define the buy strategy parameters to be used by hyperopt
+        """
+        def populate_buy_trend(dataframe: DataFrame, metadata: dict) -> DataFrame:
+            """
+            Buy strategy Hyperopt will build and use
+            """
+            dataframe.loc[
+                (
+                    (dataframe['macd'] > dataframe['macdsignal']) &
+                    (dataframe['cci'] <= params['buy-cci-value'])
+                ),
+                'buy'] = 1
+
+            return dataframe
+
+        return populate_buy_trend
+
+    @staticmethod
+    def indicator_space() -> List[Dimension]:
+        """
+        Define your Hyperopt space for searching strategy parameters
+        """
+        return [
+            Integer(-700, 0, name='buy-cci-value'),
+        ]
+
+    @staticmethod
+    def sell_strategy_generator(params: Dict[str, Any]) -> Callable:
+        """
+        Define the sell strategy parameters to be used by hyperopt
+        """
+        def populate_sell_trend(dataframe: DataFrame, metadata: dict) -> DataFrame:
+            """
+            Sell strategy Hyperopt will build and use
+            """
+            dataframe.loc[
+                (
+                    (dataframe['macd'] < dataframe['macdsignal']) &
+                    (dataframe['cci'] >= params['sell-cci-value'])
+                ),
+                'sell'] = 1
+
+            return dataframe
+
+        return populate_sell_trend
+
+    @staticmethod
+    def sell_indicator_space() -> List[Dimension]:
+        """
+        Define your Hyperopt space for searching sell strategy parameters
+        """
+        return [
+            Integer(0, 700, name='sell-cci-value'),
+        ]
+
+    @staticmethod
+    def generate_roi_table(params: Dict) -> Dict[int, float]:
+        """
+        Generate the ROI table that will be used by Hyperopt
+        """
+        roi_table = {}
+        roi_table[0] = params['roi_p1'] + params['roi_p2'] + params['roi_p3']
+        roi_table[params['roi_t3']] = params['roi_p1'] + params['roi_p2']
+        roi_table[params['roi_t3'] + params['roi_t2']] = params['roi_p1']
+        roi_table[params['roi_t3'] + params['roi_t2'] + params['roi_t1']] = 0
+
+        return roi_table
+
+    @staticmethod
+    def stoploss_space() -> List[Dimension]:
+        """
+        Stoploss Value to search
+        """
+        return [
+            Real(-0.5, -0.02, name='stoploss'),
+        ]
+
+    @staticmethod
+    def roi_space() -> List[Dimension]:
+        """
+        Values to search for each ROI steps
+        """
+        return [
+            Integer(10, 120, name='roi_t1'),
+            Integer(10, 60, name='roi_t2'),
+            Integer(10, 40, name='roi_t3'),
+            Real(0.01, 0.04, name='roi_p1'),
+            Real(0.01, 0.07, name='roi_p2'),
+            Real(0.01, 0.20, name='roi_p3'),
+        ]
+
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators. Should be a copy of from strategy
+        must align to populate_indicators in this file
+        Only used when --spaces does not include buy
+        """
+        dataframe.loc[
+            (
+                (dataframe['macd'] > dataframe['macdsignal']) &
+                (dataframe['cci'] <= -50.0)
+            ),
+            'buy'] = 1
+
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Based on TA indicators. Should be a copy of from strategy
+        must align to populate_indicators in this file
+        Only used when --spaces does not include sell
+        """
+        dataframe.loc[
+            (
+                (dataframe['macd'] < dataframe['macdsignal']) &
+                (dataframe['cci'] >= 100.0)
+            ),
+            'sell'] = 1
+
+        return dataframe


### PR DESCRIPTION
Here it is, as it was proposed in #33, an implementation (as a beginning and inspiration for other authors) of the hyperopt for MACDStrategy.

Created from the generic hyperopt template, it allows to optimize the CCI band boundaries in the MACDStrategy strategy.

Thanks to @Prossi79, this is partly his work.