### PR TITLE
The strategy should use rolling volume, not absolute mean

### DIFF
--- a/user_data/strategies/Strategy001.py
+++ b/user_data/strategies/Strategy001.py
@@ -41,7 +41,7 @@ class Strategy001(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    ta_on_candle = False
+    process_only_new_candles = False
 
     # Experimental settings (configuration will overide these if set)
     use_sell_signal = True

--- a/user_data/strategies/Strategy002.py
+++ b/user_data/strategies/Strategy002.py
@@ -42,7 +42,7 @@ class Strategy002(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    ta_on_candle = False
+    process_only_new_candles = False
 
     # Experimental settings (configuration will overide these if set)
     use_sell_signal = True

--- a/user_data/strategies/Strategy003.py
+++ b/user_data/strategies/Strategy003.py
@@ -42,7 +42,7 @@ class Strategy003(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    ta_on_candle = False
+    process_only_new_candles = False
 
     # Experimental settings (configuration will overide these if set)
     use_sell_signal = True

--- a/user_data/strategies/Strategy004.py
+++ b/user_data/strategies/Strategy004.py
@@ -41,7 +41,7 @@ class Strategy004(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    ta_on_candle = False
+    process_only_new_candles = False
 
     # Experimental settings (configuration will overide these if set)
     use_sell_signal = True
@@ -55,7 +55,7 @@ class Strategy004(IStrategy):
         'stoploss': 'market',
         'stoploss_on_exchange': False
     }
-    
+
     def informative_pairs(self):
         """
         Define additional, informative pair/interval combinations to be cached from the exchange.

--- a/user_data/strategies/Strategy005.py
+++ b/user_data/strategies/Strategy005.py
@@ -44,7 +44,7 @@ class Strategy005(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    ta_on_candle = False
+    process_only_new_candles = False
 
     # Experimental settings (configuration will overide these if set)
     use_sell_signal = True

--- a/user_data/strategies/Strategy005.py
+++ b/user_data/strategies/Strategy005.py
@@ -124,7 +124,7 @@ class Strategy005(IStrategy):
             # Prod
             (
                 (dataframe['close'] > 0.00000200) &
-                (dataframe['volume'] > dataframe['volume'].mean() * 4) &
+                (dataframe['volume'] > dataframe['volume'].rolling(200).mean() * 4) &
                 (dataframe['close'] < dataframe['sma']) &
                 (dataframe['fastd'] > dataframe['fastk']) &
                 (dataframe['rsi'] > 0) &


### PR DESCRIPTION
## Summary
Since these serve as samples, they should not contain logical errors.

using `dataframe['volume'].mean()` produces completely different signals during dry-run and backtesting - especially when backtesting longer periods.

Using a rolling mean instead will correct this. 200 was selected arbitrarily - however yields better results for  20190101-20190930 than using the mean of the whole dataframe.