### PR TITLE
Generalize ReinforcedAverageStrategy for other timeframes

### DIFF
--- a/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
@@ -58,8 +58,8 @@ class ReinforcedAverageStrategy(IStrategy):
         dataframe['bb_lowerband'] = bollinger['lower']
         dataframe['bb_upperband'] = bollinger['upper']
         dataframe['bb_middleband'] = bollinger['mid']
-
-        dataframe_long = resample_to_interval(dataframe, timeframe_to_minutes(self.ticker_interval) * 12)
+        self.resample_interval = timeframe_to_minutes(self.ticker_interval) * 12
+        dataframe_long = resample_to_interval(dataframe, self.resample_interval)
         dataframe_long['sma'] = ta.SMA(dataframe_long, timeperiod=50, price='close')
         dataframe = resampled_merge(dataframe, dataframe_long, fill_na=True)
 
@@ -75,7 +75,7 @@ class ReinforcedAverageStrategy(IStrategy):
         dataframe.loc[
             (
                 qtpylib.crossed_above(dataframe['maShort'], dataframe['maMedium']) &
-                (dataframe['close'] > dataframe['resample_2880_sma']) &
+                (dataframe['close'] > dataframe[f'resample_{self.resample_interval}_sma']) &
                 (dataframe['volume'] > 0)
             ),
             'buy'] = 1


### PR DESCRIPTION
## Summary
To make ReinforcedAverageStrategy applicable to other timeframes, the resampled interval needs to be persisted and used dynamically from the resampled columns.

closes #62 (again)
Answering the following question:
https://github.com/freqtrade/freqtrade-strategies/issues/62#issuecomment-583613866
