### PR TITLE
stochf parameters are all integers

### DIFF
--- a/user_data/strategies/berlinguyinca/CofiBitStrategy.py
+++ b/user_data/strategies/berlinguyinca/CofiBitStrategy.py
@@ -30,7 +30,7 @@ class CofiBitStrategy(IStrategy):
     ticker_interval = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-        stoch_fast = ta.STOCHF(dataframe, 5.0, 3.0, 0.0, 3.0, 0.0)
+        stoch_fast = ta.STOCHF(dataframe, 5, 3, 0, 3, 0)
         dataframe['fastd'] = stoch_fast['fastd']
         dataframe['fastk'] = stoch_fast['fastk']
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')

--- a/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
@@ -37,7 +37,7 @@ class ReinforcedSmoothScalp(IStrategy):
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')
         dataframe['ema_close'] = ta.EMA(dataframe, timeperiod=5, price='close')
         dataframe['ema_low'] = ta.EMA(dataframe, timeperiod=5, price='low')
-        stoch_fast = ta.STOCHF(dataframe, 5.0, 3.0, 0.0, 3.0, 0.0)
+        stoch_fast = ta.STOCHF(dataframe, 5, 3, 0, 3, 0)
         dataframe['fastd'] = stoch_fast['fastd']
         dataframe['fastk'] = stoch_fast['fastk']
         dataframe['adx'] = ta.ADX(dataframe)

--- a/user_data/strategies/berlinguyinca/Scalp.py
+++ b/user_data/strategies/berlinguyinca/Scalp.py
@@ -43,7 +43,7 @@ class Scalp(IStrategy):
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')
         dataframe['ema_close'] = ta.EMA(dataframe, timeperiod=5, price='close')
         dataframe['ema_low'] = ta.EMA(dataframe, timeperiod=5, price='low')
-        stoch_fast = ta.STOCHF(dataframe, 5.0, 3.0, 0.0, 3.0, 0.0)
+        stoch_fast = ta.STOCHF(dataframe, 5, 3, 0, 3, 0)
         dataframe['fastd'] = stoch_fast['fastd']
         dataframe['fastk'] = stoch_fast['fastk']
         dataframe['adx'] = ta.ADX(dataframe)

--- a/user_data/strategies/berlinguyinca/SmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/SmoothScalp.py
@@ -40,7 +40,7 @@ class SmoothScalp(IStrategy):
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')
         dataframe['ema_close'] = ta.EMA(dataframe, timeperiod=5, price='close')
         dataframe['ema_low'] = ta.EMA(dataframe, timeperiod=5, price='low')
-        stoch_fast = ta.STOCHF(dataframe, 5.0, 3.0, 0.0, 3.0, 0.0)
+        stoch_fast = ta.STOCHF(dataframe, 5, 3, 0, 3, 0)
         dataframe['fastd'] = stoch_fast['fastd']
         dataframe['fastk'] = stoch_fast['fastk']
         dataframe['adx'] = ta.ADX(dataframe)


### PR DESCRIPTION
## Summary
The latest version of ta-lib (not released, master) enforces parameters to be integers.

We're not always following this (especially with STOCHF) .

