### PR TITLE
Replace all "ticker_interval" with timeframe

### DIFF
--- a/user_data/strategies/InformativeSample.py
+++ b/user_data/strategies/InformativeSample.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 
+
 class InformativeSample(IStrategy):
     """
     Sample strategy implementing Informative Pairs - compares stake_currency with USDT.
@@ -33,8 +34,8 @@ class InformativeSample(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False
@@ -68,7 +69,7 @@ class InformativeSample(IStrategy):
                             ("BTC/USDT", "15m"),
                             ]
         """
-        return [(f"{self.config['stake_currency']}/USDT", self.ticker_interval)]
+        return [(f"{self.config['stake_currency']}/USDT", self.timeframe)]
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
@@ -85,7 +86,7 @@ class InformativeSample(IStrategy):
         if self.dp:
             # Get ohlcv data for informative pair.
             data = self.dp.get_pair_dataframe(pair=f"{self.stake_currency}/USDT",
-                                              timeframe=self.ticker_interval)
+                                              timeframe=self.timeframe)
             # Combine the 2 dataframes using 'close'.
             # This will result in a column named 'closeETH' or 'closeBTC' - depending on stake_currency.
             dataframe = dataframe.merge(data[["date", "close"]], on="date", how="left", suffixes=("", self.config['stake_currency']))

--- a/user_data/strategies/Strategy001.py
+++ b/user_data/strategies/Strategy001.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 
+
 class Strategy001(IStrategy):
     """
     Strategy 001
@@ -32,8 +33,8 @@ class Strategy001(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False

--- a/user_data/strategies/Strategy002.py
+++ b/user_data/strategies/Strategy002.py
@@ -10,6 +10,7 @@ import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 import numpy # noqa
 
+
 class Strategy002(IStrategy):
     """
     Strategy 002
@@ -33,8 +34,8 @@ class Strategy002(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False

--- a/user_data/strategies/Strategy003.py
+++ b/user_data/strategies/Strategy003.py
@@ -10,6 +10,7 @@ import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
 import numpy # noqa
 
+
 class Strategy003(IStrategy):
     """
     Strategy 003
@@ -33,8 +34,8 @@ class Strategy003(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False

--- a/user_data/strategies/Strategy004.py
+++ b/user_data/strategies/Strategy004.py
@@ -8,6 +8,7 @@ from pandas import DataFrame
 
 import talib.abstract as ta
 
+
 class Strategy004(IStrategy):
 
     """
@@ -32,8 +33,8 @@ class Strategy004(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False

--- a/user_data/strategies/Strategy005.py
+++ b/user_data/strategies/Strategy005.py
@@ -35,8 +35,8 @@ class Strategy005(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.10
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # trailing stoploss
     trailing_stop = False

--- a/user_data/strategies/berlinguyinca/ADXMomentum.py
+++ b/user_data/strategies/berlinguyinca/ADXMomentum.py
@@ -28,7 +28,7 @@ class ADXMomentum(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
+    # Optimal timeframe for the strategy
     timeframe = '1h'
 
     # Number of candles the strategy requires before producing valid signals

--- a/user_data/strategies/berlinguyinca/ASDTSRockwellTrading.py
+++ b/user_data/strategies/berlinguyinca/ASDTSRockwellTrading.py
@@ -44,8 +44,8 @@ class ASDTSRockwellTrading(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.3
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 

--- a/user_data/strategies/berlinguyinca/AdxSmas.py
+++ b/user_data/strategies/berlinguyinca/AdxSmas.py
@@ -29,8 +29,8 @@ class AdxSmas(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1h'
+    # Optimal timeframe for the strategy
+    timeframe = '1h'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['adx'] = ta.ADX(dataframe, timeperiod=14)

--- a/user_data/strategies/berlinguyinca/AverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/AverageStrategy.py
@@ -26,8 +26,8 @@ class AverageStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.2
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '4h'
+    # Optimal timeframe for the strategy
+    timeframe = '4h'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 

--- a/user_data/strategies/berlinguyinca/AwesomeMacd.py
+++ b/user_data/strategies/berlinguyinca/AwesomeMacd.py
@@ -29,8 +29,8 @@ class AwesomeMacd(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1h'
+    # Optimal timeframe for the strategy
+    timeframe = '1h'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['adx'] = ta.ADX(dataframe, timeperiod=14)

--- a/user_data/strategies/berlinguyinca/BbandRsi.py
+++ b/user_data/strategies/berlinguyinca/BbandRsi.py
@@ -29,8 +29,8 @@ class BbandRsi(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1h'
+    # Optimal timeframe for the strategy
+    timeframe = '1h'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['rsi'] = ta.RSI(dataframe, timeperiod=14)

--- a/user_data/strategies/berlinguyinca/BinHV27.py
+++ b/user_data/strategies/berlinguyinca/BinHV27.py
@@ -26,8 +26,10 @@ class BinHV27(IStrategy):
     minimal_roi = {
         "0": 1
     }
+
     stoploss = -0.50
-    ticker_interval = '5m'
+    timeframe = '5m'
+
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['rsi'] = numpy.nan_to_num(ta.RSI(dataframe, timeperiod=5))
         rsiframe = DataFrame(dataframe['rsi']).rename(columns={'rsi': 'close'})

--- a/user_data/strategies/berlinguyinca/BinHV45.py
+++ b/user_data/strategies/berlinguyinca/BinHV45.py
@@ -12,10 +12,11 @@ import freqtrade.vendor.qtpylib.indicators as qtpylib
 
 def bollinger_bands(stock_price, window_size, num_of_std):
     rolling_mean = stock_price.rolling(window=window_size).mean()
-    rolling_std  = stock_price.rolling(window=window_size).std()
+    rolling_std = stock_price.rolling(window=window_size).std()
     lower_band = rolling_mean - (rolling_std * num_of_std)
 
     return rolling_mean, lower_band
+
 
 class BinHV45(IStrategy):
     minimal_roi = {
@@ -23,7 +24,7 @@ class BinHV45(IStrategy):
     }
 
     stoploss = -0.05
-    ticker_interval = '1m'
+    timeframe = '1m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         mid, lower = bollinger_bands(dataframe['close'], window_size=40, num_of_std=2)

--- a/user_data/strategies/berlinguyinca/CCIStrategy.py
+++ b/user_data/strategies/berlinguyinca/CCIStrategy.py
@@ -20,11 +20,11 @@ class CCIStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.02
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1m'
+    # Optimal timeframe for the strategy
+    timeframe = '1m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-        dataframe = self.resample(dataframe, self.ticker_interval, 5)
+        dataframe = self.resample(dataframe, self.timeframe, 5)
 
         dataframe['cci_one'] = ta.CCI(dataframe, timeperiod=170)
         dataframe['cci_two'] = ta.CCI(dataframe, timeperiod=34)

--- a/user_data/strategies/berlinguyinca/CMCWinner.py
+++ b/user_data/strategies/berlinguyinca/CMCWinner.py
@@ -40,8 +40,8 @@ class CMCWinner(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '15m'
+    # Optimal timeframe for the strategy
+    timeframe = '15m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
@@ -57,7 +57,7 @@ class CMCWinner(IStrategy):
 
         # MFI
         dataframe['mfi'] = ta.MFI(dataframe)
-		
+
 		# CMO
         dataframe['cmo'] = ta.CMO(dataframe)
 

--- a/user_data/strategies/berlinguyinca/ClucMay72018.py
+++ b/user_data/strategies/berlinguyinca/ClucMay72018.py
@@ -36,8 +36,8 @@ class ClucMay72018(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['rsi'] = ta.RSI(dataframe, timeperiod=5)

--- a/user_data/strategies/berlinguyinca/CofiBitStrategy.py
+++ b/user_data/strategies/berlinguyinca/CofiBitStrategy.py
@@ -26,8 +26,8 @@ class CofiBitStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         stoch_fast = ta.STOCHF(dataframe, 5, 3, 0, 3, 0)

--- a/user_data/strategies/berlinguyinca/CombinedBinHAndCluc.py
+++ b/user_data/strategies/berlinguyinca/CombinedBinHAndCluc.py
@@ -24,7 +24,7 @@ class CombinedBinHAndCluc(IStrategy):
         "0": 0.05
     }
     stoploss = -0.05
-    ticker_interval = '5m'
+    timeframe = '5m'
 
     use_sell_signal = True
     sell_profit_only = True

--- a/user_data/strategies/berlinguyinca/DoesNothingStrategy.py
+++ b/user_data/strategies/berlinguyinca/DoesNothingStrategy.py
@@ -23,8 +23,8 @@ class DoesNothingStrategy(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         return dataframe

--- a/user_data/strategies/berlinguyinca/EMASkipPump.py
+++ b/user_data/strategies/berlinguyinca/EMASkipPump.py
@@ -30,8 +30,8 @@ class EMASkipPump(IStrategy):
     # should be converted to a trailing stop loss
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """ Adds several different TA indicators to the given DataFrame

--- a/user_data/strategies/berlinguyinca/Freqtrade_backtest_validation_freqtrade1.py
+++ b/user_data/strategies/berlinguyinca/Freqtrade_backtest_validation_freqtrade1.py
@@ -11,7 +11,6 @@ from pandas import DataFrame
 # Add your lib to import here
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
-import numpy
 
 
 class Freqtrade_backtest_validation_freqtrade1(IStrategy):
@@ -23,8 +22,8 @@ class Freqtrade_backtest_validation_freqtrade1(IStrategy):
         "0": 2.04
     }
 
-    stoploss = -09.90
-    ticker_interval = '1h'
+    stoploss = -0.90
+    timeframe = '1h'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         # SMA - Simple Moving Average

--- a/user_data/strategies/berlinguyinca/Low_BB.py
+++ b/user_data/strategies/berlinguyinca/Low_BB.py
@@ -42,8 +42,8 @@ class Low_BB(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.015
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1m'
+    # Optimal timeframe for the strategy
+    timeframe = '1m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         ##################################################################################

--- a/user_data/strategies/berlinguyinca/MACDStrategy.py
+++ b/user_data/strategies/berlinguyinca/MACDStrategy.py
@@ -39,8 +39,8 @@ class MACDStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.3
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 

--- a/user_data/strategies/berlinguyinca/MACDStrategy_crossed.py
+++ b/user_data/strategies/berlinguyinca/MACDStrategy_crossed.py
@@ -33,8 +33,8 @@ class MACDStrategy_crossed(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.3
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 

--- a/user_data/strategies/berlinguyinca/MultiRSI.py
+++ b/user_data/strategies/berlinguyinca/MultiRSI.py
@@ -21,11 +21,11 @@ class MultiRSI(IStrategy):
     # Optimal stoploss designed for the strategy
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def get_ticker_indicator(self):
-        return int(self.ticker_interval[:-1])
+        return int(self.timeframe[:-1])
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 

--- a/user_data/strategies/berlinguyinca/Quickie.py
+++ b/user_data/strategies/berlinguyinca/Quickie.py
@@ -31,8 +31,8 @@ class Quickie(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         macd = ta.MACD(dataframe)

--- a/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
@@ -30,8 +30,8 @@ class ReinforcedAverageStrategy(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.2
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '4h'
+    # Optimal timeframe for the strategy
+    timeframe = '4h'
 
     # trailing stoploss
     trailing_stop = False
@@ -47,7 +47,6 @@ class ReinforcedAverageStrategy(IStrategy):
     sell_profit_only = False
     ignore_roi_if_buy_signal = False
 
-
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
         dataframe['maShort'] = ta.EMA(dataframe, timeperiod=8)
@@ -58,7 +57,7 @@ class ReinforcedAverageStrategy(IStrategy):
         dataframe['bb_lowerband'] = bollinger['lower']
         dataframe['bb_upperband'] = bollinger['upper']
         dataframe['bb_middleband'] = bollinger['mid']
-        self.resample_interval = timeframe_to_minutes(self.ticker_interval) * 12
+        self.resample_interval = timeframe_to_minutes(self.timeframe) * 12
         dataframe_long = resample_to_interval(dataframe, self.resample_interval)
         dataframe_long['sma'] = ta.SMA(dataframe_long, timeperiod=50, price='close')
         dataframe = resampled_merge(dataframe, dataframe_long, fill_na=True)

--- a/user_data/strategies/berlinguyinca/ReinforcedQuickie.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedQuickie.py
@@ -37,8 +37,8 @@ class ReinforcedQuickie(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     # resample factor to establish our general trend. Basically don't buy if a trend is not given
     resample_factor = 12
@@ -48,7 +48,7 @@ class ReinforcedQuickie(IStrategy):
     EMA_LONG_TERM = 21
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-        dataframe = self.resample(dataframe, self.ticker_interval, self.resample_factor)
+        dataframe = self.resample(dataframe, self.timeframe, self.resample_factor)
 
         ##################################################################################
         # buy and sell indicators

--- a/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedSmoothScalp.py
@@ -24,9 +24,9 @@ class ReinforcedSmoothScalp(IStrategy):
     # should not be below 3% loss
 
     stoploss = -0.1
-    # Optimal ticker interval for the strategy
+    # Optimal timeframe for the strategy
     # the shorter the better
-    ticker_interval = '1m'
+    timeframe = '1m'
 
     # resample factor to establish our general trend. Basically don't buy if a trend is not given
     resample_factor = 5

--- a/user_data/strategies/berlinguyinca/Scalp.py
+++ b/user_data/strategies/berlinguyinca/Scalp.py
@@ -6,13 +6,10 @@ from pandas import DataFrame
 # --------------------------------
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
-from typing import Dict, List
-from functools import reduce
-from pandas import DataFrame, DatetimeIndex, merge
 # --------------------------------
 import talib.abstract as ta
 import freqtrade.vendor.qtpylib.indicators as qtpylib
-import numpy  # noqa
+
 
 class Scalp(IStrategy):
     """
@@ -22,8 +19,6 @@ class Scalp(IStrategy):
 
         Recommended is to only sell based on ROI for this strategy
     """
-
-
 
     # Minimal ROI designed for the strategy.
     # This attribute will be overridden if the config file contains "minimal_roi"
@@ -35,9 +30,9 @@ class Scalp(IStrategy):
     # should not be below 3% loss
 
     stoploss = -0.04
-    # Optimal ticker interval for the strategy
+    # Optimal timeframe for the strategy
     # the shorter the better
-    ticker_interval = '1m'
+    timeframe = '1m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')
@@ -54,8 +49,8 @@ class Scalp(IStrategy):
         dataframe['bb_upperband'] = bollinger['upper']
         dataframe['bb_middleband'] = bollinger['mid']
 
-
         return dataframe
+
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe.loc[
             (
@@ -69,6 +64,7 @@ class Scalp(IStrategy):
             ),
             'buy'] = 1
         return dataframe
+
     def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe.loc[
             (

--- a/user_data/strategies/berlinguyinca/Simple.py
+++ b/user_data/strategies/berlinguyinca/Simple.py
@@ -31,8 +31,8 @@ class Simple(IStrategy):
     # This attribute will be overridden if the config file contains "stoploss"
     stoploss = -0.25
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         # MACD

--- a/user_data/strategies/berlinguyinca/SmoothOperator.py
+++ b/user_data/strategies/berlinguyinca/SmoothOperator.py
@@ -34,8 +34,8 @@ class SmoothOperator(IStrategy):
     # should be converted to a trailing stop loss
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         ##################################################################################

--- a/user_data/strategies/berlinguyinca/SmoothScalp.py
+++ b/user_data/strategies/berlinguyinca/SmoothScalp.py
@@ -32,9 +32,9 @@ class SmoothScalp(IStrategy):
     # should not be below 3% loss
 
     stoploss = -0.5
-    # Optimal ticker interval for the strategy
+    # Optimal timeframe for the strategy
     # the shorter the better
-    ticker_interval = '1m'
+    timeframe = '1m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['ema_high'] = ta.EMA(dataframe, timeperiod=5, price='high')

--- a/user_data/strategies/berlinguyinca/TDSequentialStrategy.py
+++ b/user_data/strategies/berlinguyinca/TDSequentialStrategy.py
@@ -10,15 +10,15 @@ class TDSequentialStrategy(IStrategy):
     Strategy based on TD Sequential indicator.
     source:
     https://hackernoon.com/how-to-buy-sell-cryptocurrency-with-number-indicator-td-sequential-5af46f0ebce1
-    
+
     Buy trigger:
         When you see 9 consecutive closes "lower" than the close 4 bars prior.
         An ideal buy is when the low of bars 6 and 7 in the count are exceeded by the low of bars 8 or 9.
-        
+
     Sell trigger:
         When you see 9 consecutive closes "higher" than the close 4 candles prior.
         An ideal sell is when the the high of bars 6 and 7 in the count are exceeded by the high of bars 8 or 9.
-    
+
     Created by @bmoulkaf
     """
     INTERFACE_VERSION = 2
@@ -28,16 +28,16 @@ class TDSequentialStrategy(IStrategy):
 
     # Optimal stoploss designed for the strategy
     stoploss = -0.05
-    
+
     # Trailing stoploss
     trailing_stop = False
     # trailing_only_offset_is_reached = False
     # trailing_stop_positive = 0.01
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '1h'
-    
+    # Optimal timeframe for the strategy
+    timeframe = '1h'
+
     # These values can be overridden in the "ask_strategy" section in the config.
     use_sell_signal = True
     sell_profit_only = False

--- a/user_data/strategies/berlinguyinca/TechnicalExampleStrategy.py
+++ b/user_data/strategies/berlinguyinca/TechnicalExampleStrategy.py
@@ -11,8 +11,8 @@ class TechnicalExampleStrategy(IStrategy):
 
     stoploss = -0.05
 
-    # Optimal ticker interval for the strategy
-    ticker_interval = '5m'
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe['cmf'] = cmf(dataframe, 21)
@@ -23,7 +23,7 @@ class TechnicalExampleStrategy(IStrategy):
         dataframe.loc[
             (
                 (
-                        (dataframe['cmf'] < 0)
+                    (dataframe['cmf'] < 0)
 
                 )
             ),
@@ -34,7 +34,7 @@ class TechnicalExampleStrategy(IStrategy):
         # different strategy used for sell points, due to be able to duplicate it to 100%
         dataframe.loc[
             (
-                    (dataframe['cmf'] > 0)
+                (dataframe['cmf'] > 0)
             ),
             'sell'] = 1
         return dataframe


### PR DESCRIPTION
## Summary
Replace all occurances of the deprecated `ticker_interval` with `timeframe`.

This will ensure that strategies derrived from these samples are created using current best practices