### PR TITLE
mabStra Strategy + Hyperopt file

### DIFF
--- a/user_data/hyperopts/mabStra.py
+++ b/user_data/hyperopts/mabStra.py
@@ -1,0 +1,78 @@
+# author: Masoud Azizi @mablue
+
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from pandas import DataFrame
+# --------------------------------
+
+# Add your lib to import here
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+
+FTF, STF = 5, 10
+
+
+class mabStra(IStrategy):
+
+    # 100/100:    727 trades. 486/191/50 Wins/Draws/Losses. Avg profit   3.53 % . Median profit   5.97 % . Total profit  1502.52014358 USDT (2566.80Σ %). Avg duration 1396.1 min. Objective: -15.62092
+
+    # Buy hyperspace params:
+    buy_params = {
+        'buy-div-max': 0.96451, 'buy-div-min': 0.22313
+    }
+
+    # Sell hyperspace params:
+    sell_params = {
+        'sell-div-max': 0.75476, 'sell-div-min': 0.16599
+    }
+
+    # ROI table:
+    minimal_roi = {
+        "0": 0.45574,
+        "307": 0.21971,
+        "428": 0.06762,
+        "1387": 0
+    }
+
+    # Stoploss:
+    stoploss = -0.34773
+
+    # Trailing stop:
+    trailing_stop = True
+    trailing_stop_positive = 0.01573
+    trailing_stop_positive_offset = 0.06651
+     trailing_only_offset_is_reached = True
+      # Optimal timeframe use it in your config
+      timeframe = '1h'
+
+       def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+            # SMA - ex Moving Average
+            dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+            dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+            dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+            dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+            return dataframe
+
+        def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+            dataframe.loc[
+                (
+                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                        > self.buy_params['buy-div-min']) &
+                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                        < self.buy_params['buy-div-max'])
+                ),
+                'buy'] = 1
+
+            return dataframe
+
+        def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+            dataframe.loc[
+                (
+                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                        > self.sell_params['sell-div-min']) &
+                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                        < self.sell_params['sell-div-max'])
+                ),
+                'sell'] = 1
+            return dataframe

--- a/user_data/hyperopts/mabStra.py
+++ b/user_data/hyperopts/mabStra.py
@@ -41,38 +41,38 @@ class mabStra(IStrategy):
     trailing_stop = True
     trailing_stop_positive = 0.01573
     trailing_stop_positive_offset = 0.06651
-     trailing_only_offset_is_reached = True
-      # Optimal timeframe use it in your config
-      timeframe = '1h'
+    trailing_only_offset_is_reached = True
+    # Optimal timeframe use it in your config
+    timeframe = '1h'
 
-       def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-            # SMA - ex Moving Average
-            dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
-            dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
-            dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
-            dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
-            return dataframe
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        # SMA - ex Moving Average
+        dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        return dataframe
 
-        def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
-            dataframe.loc[
-                (
-                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
-                        > self.buy_params['buy-div-min']) &
-                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
-                        < self.buy_params['buy-div-max'])
-                ),
-                'buy'] = 1
+        dataframe.loc[
+            (
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    > self.buy_params['buy-div-min']) &
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    < self.buy_params['buy-div-max'])
+            ),
+            'buy'] = 1
 
-            return dataframe
+        return dataframe
 
-        def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-            dataframe.loc[
-                (
-                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
-                        > self.sell_params['sell-div-min']) &
-                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
-                        < self.sell_params['sell-div-max'])
-                ),
-                'sell'] = 1
-            return dataframe
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    > self.sell_params['sell-div-min']) &
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    < self.sell_params['sell-div-max'])
+            ),
+            'sell'] = 1
+        return dataframe

--- a/user_data/strategies/mabStra.py
+++ b/user_data/strategies/mabStra.py
@@ -1,0 +1,78 @@
+# author: Masoud Azizi @mablue
+
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from pandas import DataFrame
+# --------------------------------
+
+# Add your lib to import here
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+
+FTF, STF = 5, 10
+
+
+class mabStra(IStrategy):
+
+    # 100/100:    727 trades. 486/191/50 Wins/Draws/Losses. Avg profit   3.53 % . Median profit   5.97 % . Total profit  1502.52014358 USDT (2566.80Σ %). Avg duration 1396.1 min. Objective: -15.62092
+
+    # Buy hyperspace params:
+    buy_params = {
+        'buy-div-max': 0.96451, 'buy-div-min': 0.22313
+    }
+
+    # Sell hyperspace params:
+    sell_params = {
+        'sell-div-max': 0.75476, 'sell-div-min': 0.16599
+    }
+
+    # ROI table:
+    minimal_roi = {
+        "0": 0.45574,
+        "307": 0.21971,
+        "428": 0.06762,
+        "1387": 0
+    }
+
+    # Stoploss:
+    stoploss = -0.34773
+
+    # Trailing stop:
+    trailing_stop = True
+    trailing_stop_positive = 0.01573
+    trailing_stop_positive_offset = 0.06651
+     trailing_only_offset_is_reached = True
+      # Optimal timeframe use it in your config
+      timeframe = '1h'
+
+       def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+            # SMA - ex Moving Average
+            dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+            dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+            dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+            dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+            return dataframe
+
+        def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+            dataframe.loc[
+                (
+                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                        > self.buy_params['buy-div-min']) &
+                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                        < self.buy_params['buy-div-max'])
+                ),
+                'buy'] = 1
+
+            return dataframe
+
+        def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+            dataframe.loc[
+                (
+                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                        > self.sell_params['sell-div-min']) &
+                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                        < self.sell_params['sell-div-max'])
+                ),
+                'sell'] = 1
+            return dataframe

--- a/user_data/strategies/mabStra.py
+++ b/user_data/strategies/mabStra.py
@@ -41,38 +41,38 @@ class mabStra(IStrategy):
     trailing_stop = True
     trailing_stop_positive = 0.01573
     trailing_stop_positive_offset = 0.06651
-     trailing_only_offset_is_reached = True
-      # Optimal timeframe use it in your config
-      timeframe = '1h'
+    trailing_only_offset_is_reached = True
+    # Optimal timeframe use it in your config
+    timeframe = '1h'
 
-       def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-            # SMA - ex Moving Average
-            dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
-            dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
-            dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
-            dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
-            return dataframe
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        # SMA - ex Moving Average
+        dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        return dataframe
 
-        def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
-            dataframe.loc[
-                (
-                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
-                        > self.buy_params['buy-div-min']) &
-                    (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
-                        < self.buy_params['buy-div-max'])
-                ),
-                'buy'] = 1
+        dataframe.loc[
+            (
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    > self.buy_params['buy-div-min']) &
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    < self.buy_params['buy-div-max'])
+            ),
+            'buy'] = 1
 
-            return dataframe
+        return dataframe
 
-        def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
-            dataframe.loc[
-                (
-                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
-                        > self.sell_params['sell-div-min']) &
-                    (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
-                        < self.sell_params['sell-div-max'])
-                ),
-                'sell'] = 1
-            return dataframe
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    > self.sell_params['sell-div-min']) &
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    < self.sell_params['sell-div-max'])
+            ),
+            'sell'] = 1
+        return dataframe


### PR DESCRIPTION
SMA division Strategy with hyperopt
you can use EMA and etc to divid and check the result. 

I thested with this config:
```
    "max_open_trades": 100,
    "stake_currency": "USDT",
    "stake_amount": "unlimited",
    "tradable_balance_ratio": 1,
    "fiat_display_currency": "USD",
    "timeframe": "1h",
    "dry_run": true,
    "dry_run_wallet": 5000,
    "cancel_open_orders_on_exit": false,
    "unfilledtimeout": {
        "buy": 10,
        "sell": 30
    },
.
.
.
        "pair_whitelist": [
            ".*/USDT"
        ],
        "pair_blacklist": [
            ".*UP/USDT",
            ".*DOWN/USDT",
            ".*BULL/USDT",
            ".*BEAR/USDT",
            "PAX/USDT",
            "BUSD/USDT",
            "USDC/USDT",
            "TUSD/USDT"
        ]
.
.
.
```
`
freqtrade hyperopt --hyperopt mabStraHo --hyperopt-loss SharpeHyperOptLossDaily --spaces all --strategy mabStra --config config.json -e 100`
```

+--------+---------+----------+------------------+--------------+-------------------------------+----------------+-------------+                                                                                           
|   Best |   Epoch |   Trades |    Win Draw Loss |   Avg profit |                        Profit |   Avg duration |   Objective |
|--------+---------+----------+------------------+--------------+-------------------------------+----------------+-------------|
| * Best |   6/100 |        1 |      0    0    1 |      -23.88% |  -11.95147670 USDT  (-23.88%) |        360.0 m |     3.02076 |
| * Best |   8/100 |        1 |      0    0    1 |      -31.15% |  -15.59218535 USDT  (-31.15%) |        780.0 m |     3.02076 |
| * Best |  16/100 |      736 |    377  287   72 |        2.81% | 1,137.90245109 USDT (2,067.51%) |      1,605.4 m |    -9.02192 |                                                                                         
| * Best |  18/100 |     2557 |   1674  766  117 |        1.71% | 3,059.46343886 USDT (4,366.40%) |      1,533.3 m |    -9.94778 |                                                                                         
|   Best |  33/100 |      438 |    300   92   46 |        3.05% | 713.65453501 USDT (1,334.45%) |      1,552.2 m |    -10.3577 |                                                                                           
|   Best |  52/100 |     2643 |   2338   79  226 |        1.40% | 2,821.81442233 USDT (3,692.00%) |        205.8 m |    -14.5472 |                                                                                         
|   Best | 100/100 |      727 |    486  191   50 |        3.53% | 1,502.52014358 USDT (2,566.80%) |      1,396.1 m |    -15.6209 |                                                                                         
```