### PR TITLE
mabStra Strategy + Hyperopt

### DIFF
--- a/user_data/hyperopts/mabStraHo.py
+++ b/user_data/hyperopts/mabStraHo.py
@@ -1,0 +1,95 @@
+# by: Mablue (Masoud Azizi)
+
+# --- Do not remove these libs ---
+from functools import reduce
+from typing import Any, Callable, Dict, List
+
+import numpy as np  # noqa
+import pandas as pd  # noqa
+from pandas import DataFrame
+from skopt.space import Categorical, Dimension, Integer, Real  # noqa
+
+from freqtrade.optimize.hyperopt_interface import IHyperOpt
+
+# --------------------------------
+# Add your lib to import here
+import talib.abstract as ta  # noqa
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+
+
+class mabStraHo(IHyperOpt):
+
+    @staticmethod
+    def indicator_space() -> List[Dimension]:
+        """
+        Define your Hyperopt space for searching buy strategy parameters.
+        """
+        return [
+            Real(0, 1, name='buy-div-min'),
+            Real(0, 1, name='buy-div-max'),
+        ]
+
+    @staticmethod
+    def buy_strategy_generator(params: Dict[str, Any]) -> Callable:
+        """
+        Define the buy strategy parameters to be used by Hyperopt.
+        """
+        def populate_buy_trend(dataframe: DataFrame, metadata: dict) -> DataFrame:
+            """
+            Buy strategy Hyperopt will build and use.
+            """
+            conditions = []
+            # GUARDS AND TRENDS
+
+            # div result limited to 0~1 so allways in buy position slowMa is lower than fastMa
+            # optimum number will calculate by this two lines
+            conditions.append(dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                              > params['buy-div-min'])
+            conditions.append(dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                              < params['buy-div-max'])
+
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'buy'] = 1
+
+            return dataframe
+
+        return populate_buy_trend
+
+    @staticmethod
+    def sell_indicator_space() -> List[Dimension]:
+        """
+        Define your Hyperopt space for searching sell strategy parameters.
+        """
+        return [
+            Real(0, 1, name='sell-div-min'),
+            Real(0, 1, name='sell-div-max'),
+        ]
+
+    @staticmethod
+    def sell_strategy_generator(params: Dict[str, Any]) -> Callable:
+        """
+        Define the sell strategy parameters to be used by Hyperopt.
+        """
+        def populate_sell_trend(dataframe: DataFrame, metadata: dict) -> DataFrame:
+            """
+            Sell strategy Hyperopt will build and use.
+            """
+            conditions = []
+
+            # GUARDS AND TRENDS
+
+            conditions.append(dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                              > params['sell-div-min'])
+            conditions.append(dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                              < params['sell-div-max'])
+
+            if conditions:
+                dataframe.loc[
+                    reduce(lambda x, y: x & y, conditions),
+                    'sell'] = 1
+
+            return dataframe
+
+        return populate_sell_trend

--- a/user_data/strategies/mabStra.py
+++ b/user_data/strategies/mabStra.py
@@ -1,0 +1,78 @@
+# author: Masoud Azizi @mablue
+
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from pandas import DataFrame
+# --------------------------------
+
+# Add your lib to import here
+import talib.abstract as ta
+import freqtrade.vendor.qtpylib.indicators as qtpylib
+
+FTF, STF = 5, 10
+
+
+class mabStra(IStrategy):
+
+    # 100/100:    727 trades. 486/191/50 Wins/Draws/Losses. Avg profit   3.53 % . Median profit   5.97 % . Total profit  1502.52014358 USDT (2566.80Σ %). Avg duration 1396.1 min. Objective: -15.62092
+
+    # Buy hyperspace params:
+    buy_params = {
+        'buy-div-max': 0.96451, 'buy-div-min': 0.22313
+    }
+
+    # Sell hyperspace params:
+    sell_params = {
+        'sell-div-max': 0.75476, 'sell-div-min': 0.16599
+    }
+
+    # ROI table:
+    minimal_roi = {
+        "0": 0.45574,
+        "307": 0.21971,
+        "428": 0.06762,
+        "1387": 0
+    }
+
+    # Stoploss:
+    stoploss = -0.34773
+
+    # Trailing stop:
+    trailing_stop = True
+    trailing_stop_positive = 0.01573
+    trailing_stop_positive_offset = 0.06651
+    trailing_only_offset_is_reached = True
+    # Optimal timeframe use it in your config
+    timeframe = '1h'
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        # SMA - ex Moving Average
+        dataframe['buy-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['buy-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        dataframe['sell-fastMA'] = ta.SMA(dataframe, timeperiod=FTF)
+        dataframe['sell-slowMA'] = ta.SMA(dataframe, timeperiod=STF)
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            (
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    > self.buy_params['buy-div-min']) &
+                (dataframe['buy-fastMA'].div(dataframe['buy-slowMA'])
+                    < self.buy_params['buy-div-max'])
+            ),
+            'buy'] = 1
+
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    > self.sell_params['sell-div-min']) &
+                (dataframe['sell-slowMA'].div(dataframe['sell-fastMA'])
+                    < self.sell_params['sell-div-max'])
+            ),
+            'sell'] = 1
+        return dataframe


### PR DESCRIPTION
mabStra is a simple moving averages division strategy + hyperopt file
You can change FTF, STF = 5, 10 to change FastMa and SlowMA timeframes(be carefull FTF will smaller number than STF)

Do hyperopt:
`freqtrade hyperopt --hyperopt mabStraHo --hyperopt-loss SharpeHyperOptLossDaily --spaces all --strategy mabStra --config config.json -e 1000`
```
+--------+-----------+----------+------------------+--------------+-----------------------------------+----------------+-------------+
|   Best |     Epoch |   Trades |    Win Draw Loss |   Avg profit |                            Profit |   Avg duration |   Objective |
|--------+-----------+----------+------------------+--------------+-----------------------------------+----------------+-------------|
| * Best |    1/1000 |     5446 |   1958   17 3471 |       -0.57% | -1,826.97391040 USDT (-3,097.35%) |        239.6 m |     6.80044 |
| * Best |    2/1000 |        1 |      0    0    1 |      -22.66% |  -11.34147638 USDT  (-22.66%) |        720.0 m |     3.02076 |                                      
| * Best |   20/1000 |      134 |     72   47   15 |        1.91% |  129.06851254 USDT  (256.07%) |      1,396.6 m |    -3.48951 |                                      
| * Best |   21/1000 |     1751 |   1023  588  140 |        2.72% | 2,896.41684894 USDT (4,762.25%) |      2,784.2 m |    -10.0418 |
|   Best |   40/1000 |     2698 |   1120 1443  135 |        1.77% | 2,980.94128514 USDT (4,766.55%) |      1,896.5 m |      -11.56 |                                    
|   Best |   54/1000 |     2049 |   1196  701  152 |        2.60% | 3,406.42233657 USDT (5,332.07%) |      2,531.3 m |    -11.9458 |                                    
|   Best |   67/1000 |      519 |    289  189   41 |        3.40% | 967.17764255 USDT (1,762.91%) |      1,939.0 m |    -13.4827 |                                      
|   Best |  168/1000 |     1255 |   1068  113   74 |        1.73% | 1,302.23528577 USDT (2,176.66%) |        537.2 m |    -14.9015 |                                    
|   Best |  413/1000 |     1368 |   1046  258   64 |        2.78% | 2,388.32492115 USDT (3,796.80%) |      1,011.8 m |    -14.9644 |                                    
```

I thested with this config:
```
.
.
.
    "max_open_trades": 100,
    "stake_currency": "USDT",
    "stake_amount": "unlimited",
    "tradable_balance_ratio": 1,
    "fiat_display_currency": "USD",
    "timeframe": "1h",
    "dry_run": true,
    "dry_run_wallet": 5000,
    "cancel_open_orders_on_exit": false,
    "unfilledtimeout": {
        "buy": 10,
        "sell": 30
    },
.
.
.
        "pair_whitelist": [
            ".*/USDT"
        ],
        "pair_blacklist": [
            ".*UP/USDT",
            ".*DOWN/USDT",
            ".*BULL/USDT",
            ".*BEAR/USDT",
            "PAX/USDT",
            "BUSD/USDT",
            "USDC/USDT",
            "TUSD/USDT"
        ]
.
.
.

```