### PR TITLE
BreakEven.py -- sell everything at 0% or better profit

### DIFF
--- a/user_data/strategies/BreakEven.py
+++ b/user_data/strategies/BreakEven.py
@@ -43,7 +43,7 @@ class BreakEven(IStrategy):
 #    }
 
     # Optimal stoploss designed for the strategy
-    stoploss = -0.25
+    stoploss = -0.05
 
     # Optimal timeframe for the strategy
     timeframe = '5m'

--- a/user_data/strategies/BreakEven.py
+++ b/user_data/strategies/BreakEven.py
@@ -1,0 +1,67 @@
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from pandas import DataFrame
+# --------------------------------
+
+
+class BreakEven(IStrategy):
+    """
+    author@: lenik
+
+    Sometimes I want to close the bot ASAP, but not have the positions floating around.
+
+    I can "/stopbuy" and wait for the positions to get closed by the bot rules, which is
+    waiting for some profit, etc -- this usually takes too long...
+    
+    What I would prefer is to close everything that is over 0% profit to avoid the losses.
+
+    Here's a simple strategy with empty buy/sell signals and "minimal_roi = { 0 : 0 }" that
+    sells everything already at profit and wait until the positions at loss will come to break
+    even point (or the small profit you provide in ROI table).
+    
+    You may restart the bot with the new strategy as a command-line parameter.
+
+    Another way would be to specify the original strategy in the config file, then change to
+    this one and simply "/reload_config" from the Telegram bot.
+
+    """
+
+    # This attribute will be overridden if the config file contains "minimal_roi"
+    minimal_roi = {
+        "0": 0.01,      # at least 1% at first
+        "10": 0         # after 10min, everything goes 
+    }
+
+    # This is more radical version that sells everything above the profit level
+#    minimal_roi = {
+#        "0": 0
+#    }
+
+    # And this is basically "/forcesell all", that sells no matter what profit
+#    minimal_roi = {
+#        "0": -1
+#    }
+
+    # Optimal stoploss designed for the strategy
+    stoploss = -0.25
+
+    # Optimal timeframe for the strategy
+    timeframe = '5m'
+
+    # don't generate any buy or sell signals, everything is handled by ROI and stop_loss
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+            ),
+            'buy'] = 0
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+            ),
+            'sell'] = 0
+        return dataframe


### PR DESCRIPTION
## Summary

In case I want to stop the bot ASAP, this strategy sells everything at break even or better profit. A bit less radical version of `/forcesell all`, if you want.

## Quick strategy idea

Ignore sell / buy signals, set up `minimal_roi` to `{ 0 : 0 }` to make sure all open positions currently above the break even level are sold, wait for the rest to either rise or sink down to `stop_loss` level.