### PR TITLE
Fix MultiMa to not give an error

### DIFF
--- a/user_data/strategies/MultiMa.py
+++ b/user_data/strategies/MultiMa.py
@@ -7,6 +7,7 @@
 from freqtrade.strategy.hyper import IntParameter
 from freqtrade.strategy.interface import IStrategy
 from pandas import DataFrame
+
 # --------------------------------
 
 # Add your lib to import here
@@ -17,29 +18,24 @@ from functools import reduce
 
 class MultiMa(IStrategy):
 
-    buy_ma_count = IntParameter(2, 10, default=10, space='buy')
-    buy_ma_gap = IntParameter(2, 10, default=2, space='buy')
-    buy_ma_shift = IntParameter(0, 10, default=0, space='buy')
+    buy_ma_count = IntParameter(0, 10, default=10, space="buy")
+    buy_ma_gap = IntParameter(2, 10, default=2, space="buy")
+    buy_ma_shift = IntParameter(0, 10, default=0, space="buy")
     # buy_ma_rolling = IntParameter(0, 10, default=0, space='buy')
 
-    sell_ma_count = IntParameter(2, 10, default=10, space='sell')
-    sell_ma_gap = IntParameter(2, 10, default=2, space='sell')
-    sell_ma_shift = IntParameter(0, 10, default=0, space='sell')
+    sell_ma_count = IntParameter(0, 10, default=10, space="sell")
+    sell_ma_gap = IntParameter(2, 10, default=2, space="sell")
+    sell_ma_shift = IntParameter(, 10, default=0, space="sell")
     # sell_ma_rolling = IntParameter(0, 10, default=0, space='sell')
 
     # ROI table:
-    minimal_roi = {
-        "0": 0.30873,
-        "569": 0.16689,
-        "3211": 0.06473,
-        "7617": 0
-    }
+    minimal_roi = {"0": 0.30873, "569": 0.16689, "3211": 0.06473, "7617": 0}
 
     # Stoploss:
-    stoploss = -0.128
+    stoploss = -0.1
 
     # Buy hypers
-    timeframe = '4h'
+    timeframe = "4h"
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
@@ -52,8 +48,9 @@ class MultiMa(IStrategy):
     def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
 
         for i in self.buy_ma_count.range:
-            dataframe[f'buy-ma-{i+1}'] = ta.SMA(dataframe,
-                                                timeperiod=int((i+1) * self.buy_ma_gap.value))
+            dataframe[f"buy-ma-{i+1}"] = ta.SMA(
+                dataframe, timeperiod=int((i + 1) * self.buy_ma_gap.value)
+            )
 
         conditions = []
 
@@ -62,20 +59,19 @@ class MultiMa(IStrategy):
                 shift = self.buy_ma_shift.value
                 for shift in self.buy_ma_shift.range:
                     conditions.append(
-                        dataframe[f'buy-ma-{i}'].shift(shift) >
-                        dataframe[f'buy-ma-{i-1}'].shift(shift)
+                        dataframe[f"buy-ma-{i}"].shift(shift)
+                        > dataframe[f"buy-ma-{i-1}"].shift(shift)
                     )
         if conditions:
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'buy']=1
+            dataframe.loc[reduce(lambda x, y: x & y, conditions), "buy"] = 1
 
         return dataframe
 
     def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         for i in self.sell_ma_count.range:
-            dataframe[f'sell-ma-{i+1}'] = ta.SMA(dataframe,
-                                                 timeperiod=int((i+1) * self.sell_ma_gap.value))
+            dataframe[f"sell-ma-{i+1}"] = ta.SMA(
+                dataframe, timeperiod=int((i + 1) * self.sell_ma_gap.value)
+            )
 
         conditions = []
 
@@ -84,11 +80,9 @@ class MultiMa(IStrategy):
                 shift = self.sell_ma_shift.value
                 for shift in self.sell_ma_shift.range:
                     conditions.append(
-                        dataframe[f'sell-ma-{i}'].shift(shift) <
-                        dataframe[f'sell-ma-{i-1}'].shift(shift)
+                        dataframe[f"sell-ma-{i}"].shift(shift)
+                        < dataframe[f"sell-ma-{i-1}"].shift(shift)
                     )
         if conditions:
-            dataframe.loc[
-                reduce(lambda x, y: x & y, conditions),
-                'sell']=1
+            dataframe.loc[reduce(lambda x, y: x & y, conditions), "sell"] = 1
         return dataframe


### PR DESCRIPTION
Fixing buy_ma_count's Int Parameter value since they cause an error.
In more detail, the old version had buy_ma_count starting off at 2, then had a buy-ma plus 1. 
Then the smallest period(e.g dataframe["buy-ma-3"]), is 3.
But in the old code, there is dataframe[f"buy-ma-{i-1}"], if i is equal 3, then i - 1 is equal to 2. 
So forth causing an exception, as there is no dataframe["buy-ma-2"] as the smallest period is dataframe["buy-ma-3"]. 
The same thing happens if buy_ma_count's low value is equal to 1.
The same thing happens on the sell-side.
The only way to fix it is to have buy/sell_ma_count's low value set to 0.
There are also some formats(from the black formatter(https://github.com/psf/black)).