### PR TITLE
Fix typo in last fix

### DIFF
--- a/user_data/strategies/MultiMa.py
+++ b/user_data/strategies/MultiMa.py
@@ -25,7 +25,7 @@ class MultiMa(IStrategy):
 
     sell_ma_count = IntParameter(0, 10, default=10, space="sell")
     sell_ma_gap = IntParameter(2, 10, default=2, space="sell")
-    sell_ma_shift = IntParameter(, 10, default=0, space="sell")
+    sell_ma_shift = IntParameter(0, 10, default=0, space="sell")
     # sell_ma_rolling = IntParameter(0, 10, default=0, space='sell')
 
     # ROI table:


### PR DESCRIPTION


## Summary

prevents: freqtrade.resolvers.iresolver - WARNING - Could not import /home/$USERNAME/freqtrade/user_data/strategies/MultiMa.py due to 'invalid syntax (MultiMa.py, line 28)'


