### PR TITLE
Set process candles to True

### DIFF
--- a/user_data/strategies/futures/FSampleStrategy.py
+++ b/user_data/strategies/futures/FSampleStrategy.py
@@ -40,7 +40,7 @@ class FSampleStrategy(IStrategy):
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
     # Run "populate_indicators()" only for new candle.
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Number of candles the strategy requires before producing valid signals
     startup_candle_count: int = 30


### PR DESCRIPTION
## Summary

There's no reason for `process_only_new_candles` to be False in this strategy example as there's no ticker/websocket data being used, just candles.