### PR TITLE
Update example strategies to use process_only_new_candles=True

### DIFF
--- a/user_data/strategies/Strategy001.py
+++ b/user_data/strategies/Strategy001.py
@@ -43,7 +43,7 @@ class Strategy001(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/Strategy001_custom_exit.py
+++ b/user_data/strategies/Strategy001_custom_exit.py
@@ -44,7 +44,7 @@ class Strategy001_custom_exit(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/Strategy002.py
+++ b/user_data/strategies/Strategy002.py
@@ -44,7 +44,7 @@ class Strategy002(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/Strategy003.py
+++ b/user_data/strategies/Strategy003.py
@@ -44,7 +44,7 @@ class Strategy003(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/Strategy004.py
+++ b/user_data/strategies/Strategy004.py
@@ -43,7 +43,7 @@ class Strategy004(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/Strategy005.py
+++ b/user_data/strategies/Strategy005.py
@@ -45,7 +45,7 @@ class Strategy005(IStrategy):
     trailing_stop_positive_offset = 0.02
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
+++ b/user_data/strategies/berlinguyinca/ReinforcedAverageStrategy.py
@@ -41,7 +41,7 @@ class ReinforcedAverageStrategy(IStrategy):
     trailing_only_offset_is_reached = False
 
     # run "populate_indicators" only for new candle
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Experimental settings (configuration will overide these if set)
     use_exit_signal = True

--- a/user_data/strategies/futures/FAdxSmaStrategy.py
+++ b/user_data/strategies/futures/FAdxSmaStrategy.py
@@ -41,7 +41,7 @@ class FAdxSmaStrategy(IStrategy):
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
     # Run "populate_indicators()" only for new candle.
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Number of candles the strategy requires before producing valid signals
     startup_candle_count: int = 14

--- a/user_data/strategies/futures/FReinforcedStrategy.py
+++ b/user_data/strategies/futures/FReinforcedStrategy.py
@@ -43,7 +43,7 @@ class FReinforcedStrategy(IStrategy):
     # trailing_stop_positive_offset = 0.0  # Disabled / not configured
 
     # Run "populate_indicators()" only for new candle.
-    process_only_new_candles = False
+    process_only_new_candles = True
 
     # Number of candles the strategy requires before producing valid signals
     startup_candle_count: int = 14


### PR DESCRIPTION
## Summary

A lot of the example strategies have been set to use `process_only_new_candles=False`, which will not provide any functionality as they only use OHLCV data. This PR sets all cases of `process_only_new_candles` to `True`
